### PR TITLE
Fix ending slash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 .codeclimate.yml export-ignore
 .travis.yml      export-ignore
 phpunit.xml.dist export-ignore
+CONTRIBUTING.md  export-ignore

--- a/src/Router.php
+++ b/src/Router.php
@@ -114,11 +114,14 @@ class Router
         $requestArray = explode('/', $request);
         $pathArray = explode('/', $route->getPath());
 
+        // Remove empty values in arrays
+        $requestArray = array_values(array_filter($requestArray, 'strlen'));
+        $pathArray = array_values(array_filter($pathArray, 'strlen'));
+
         if (!(count($requestArray) === count($pathArray))
             || !(in_array($_SERVER['REQUEST_METHOD'], $route->getMethods(), true))) {
             return false;
         }
-        unset($pathArray[0]);
 
         foreach ($pathArray as $index => $urlPart) {
             if (isset($requestArray[$index])) {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -78,6 +78,15 @@ class RouterTest extends TestCase
         self::assertEquals('5', $match['params']['id']);
     }
 
+    public function testMatchWithEndingSlash(): void
+    {
+        $this->setRequestGlobals('/contact/');
+        $match = $this->router->match();
+
+        self::assertEquals(TestController::class, $match['class']);
+        self::assertEquals(TestController::CONTACT_METHOD, $match['method']);
+    }
+
     public function testInvalidParamOnDynamicRoute(): void
     {
         $this->setRequestGlobals('/blog/hello-world/comment/id');


### PR DESCRIPTION
Fix #16 

Fixed an issue that caused routes to fail to match when a slash was at the end of the request.
The arrays containing each part of the query and route are now cleaning up empty values ​​which potentially fixes other issues.